### PR TITLE
복잡한 DOM 구조에서 리스트가 보이지 않던 문제를 해결합니다.

### DIFF
--- a/html_extract/popup.html
+++ b/html_extract/popup.html
@@ -10,6 +10,10 @@
     span{
         border: 1px solid blue
     }
+    .ol__contentBody {
+        overflow-x: auto;
+        overflow-y: hidden;
+    }
     </style>
 </head>
 <body>


### PR DESCRIPTION
<img width="654" alt="Screen Shot 2019-06-21 at 4 01 38 PM" src="https://user-images.githubusercontent.com/19797697/59904405-6121d080-943e-11e9-999d-b0723538343f.png">

페이지의 DOM 구조가 복잡한 경우 들여쓰기가 깊은 리스트들이 popup.html의 가로 사이즈인 400px보다 넘게 되어 보이지 않는 문제를 수정합니다. (위 스크린샷 참고)

이제 아래 gif와 같이 가로 스크롤을 추가하여 복잡한 DOM 구조에서도 스크롤을 하여 모든 리스트를 볼 수 있습니다.

![Jun-21-2019 16-10-20](https://user-images.githubusercontent.com/19797697/59904674-1ce30000-943f-11e9-8648-4840f1bca78f.gif)
